### PR TITLE
Added one-hot encoding for categorical data

### DIFF
--- a/datasets/abalone.data
+++ b/datasets/abalone.data
@@ -1,4 +1,4 @@
-Sex,Length,Diameter,Height,Whole_weight,Shucked_weight,Viscera_weight,Shell_weight,Rings
+Sex(cat),Length,Diameter,Height,Whole_weight,Shucked_weight,Viscera_weight,Shell_weight,Rings
 M,0.455,0.365,0.095,0.514,0.2245,0.101,0.15,15
 M,0.35,0.265,0.09,0.2255,0.0995,0.0485,0.07,7
 F,0.53,0.42,0.135,0.677,0.2565,0.1415,0.21,9

--- a/datasets/processed.cleveland.data
+++ b/datasets/processed.cleveland.data
@@ -1,4 +1,4 @@
-age,sex,cp,trestbps,chol,fbs,restecg,thalach,exang,oldpeak,slope,ca,thal,num
+age,sex(cat),cp(cat),trestbps,chol,fbs(cat),restecg(cat),thalach,exang(cat),oldpeak,slope,ca,thal(cat),num
 63.0,1.0,1.0,145.0,233.0,1.0,2.0,150.0,0.0,2.3,3.0,0.0,6.0,0
 67.0,1.0,4.0,160.0,286.0,0.0,2.0,108.0,1.0,1.5,2.0,3.0,3.0,2
 67.0,1.0,4.0,120.0,229.0,0.0,2.0,129.0,1.0,2.6,2.0,2.0,7.0,1


### PR DESCRIPTION
* Got rid of is_numeric_col and the non-vectorised euc function.
* Categorical columns can be marked with '(cat)', needed to do this as some categorical columns on UCI already use integer encoding.
* Currently dropping missing values from dataset, users can specify a list of strings denoting missing values such as '?' -> should ask supervisor about this.